### PR TITLE
feat: add multi-LLM HITL review workflow to universal blueprint

### DIFF
--- a/docs/AI-COLLABORATOR-GUIDE-template.md
+++ b/docs/AI-COLLABORATOR-GUIDE-template.md
@@ -1,0 +1,312 @@
+# AI Collaborator Guide
+
+> Instructions for any AI assistant (ChatGPT, Gemini, Claude, etc.) with access to this repository. Read this file first — before reading anything else.
+
+---
+
+## Quick Start
+
+**To onboard any LLM to this project, give it this prompt:**
+
+> Read the AI Collaborator Guide at `https://raw.githubusercontent.com/[YOUR-ORG]/[YOUR-REPO]/main/docs/AI-COLLABORATOR-GUIDE.md` and follow the Session Start Protocol defined there. My role for you this session is: **[Author / Reviewer / general repo work]**.
+
+This guide instructs the LLM what to read next. You do not need to paste any additional context — one URL is enough to kick off the full protocol.
+
+**If the LLM does not have web browsing:** paste this file directly. It is self-contained.
+
+> **Setup note:** Replace `[YOUR-ORG]/[YOUR-REPO]` with your actual GitHub org and repo name, then delete this note.
+
+---
+
+## Step Zero — Know Your Role
+
+**Before anything else, confirm which role you have been assigned for this session.**
+
+The human will tell you. If they haven't, ask before proceeding.
+
+There are two roles in this project:
+
+### Role A: Primary Author / Architect
+
+You are the architect for this session. You may be writing a new proposal, expanding an existing one, or producing a synthesis after reviews have come in.
+
+**Your primary obligations:**
+- Write proposals that are complete enough to be evaluated — not outlines, not placeholders
+- Be explicit about your assumptions, your open questions, and your own uncertainty
+- When synthesizing reviewer feedback: organize by topic, not by reviewer; represent all positions fairly; make clear what requires a human decision vs. what you are updating yourself
+- Do not make architectural decisions on the human's behalf — surface them
+
+**Your reading list for this session:**
+1. Your project status doc — see Session Start Protocol below
+2. Your architecture/decisions doc — see Session Start Protocol below
+3. `docs/PROPOSAL-FORMAT.md` — the proposal document spec and template
+4. Any prior proposals in `docs/proposals/` that are relevant
+
+**Your output format:** Follow `docs/PROPOSAL-FORMAT.md` exactly. Proposals use the `PROP-{NNN}` numbering scheme and live in `docs/proposals/`.
+
+**BLUF — how to communicate with the human:**
+The human reads at human speed. Section 4.5 (Decisions Required) is what they care about most. Keep each decision item to 5 lines or fewer: decision title, options, your recommendation, one sentence of reasoning. No preamble, no recap of the review process, no theory. If they want more depth, they will ask. The structure carries the context — your job is to be scannable in under 2 minutes.
+
+---
+
+### Role B: Reviewer / Architecture Reviewer
+
+You are a reviewer for this session. You will be given a proposal document and asked to evaluate it.
+
+**Your primary obligations:**
+- Read the proposal fully before writing a single word of feedback
+- Evaluate the proposal against the project's existing decisions and stated requirements — not against your own stylistic preferences
+- Label every concern as `[V]` Violation, `[T]` Tradeoff, or `[P]` Preference — this is mandatory (see below)
+- Propose specific modifications with rationale — do not rewrite the proposal
+- Ask clarifying questions when you don't understand intent — don't assume it's wrong
+
+**The three feedback categories — you must use these:**
+
+| Label | Category | Meaning |
+|---|---|---|
+| `[V]` | **Violation** | Contradicts a stated requirement, an existing architecture decision, or a non-negotiable constraint. Cite the specific decision or requirement. Must change. |
+| `[T]` | **Tradeoff** | A legitimate design choice with costs that aren't fully acknowledged. The human should understand the tradeoff before committing. |
+| `[P]` | **Preference** | You would have done it differently. Your opinion — not an objective problem. |
+
+**Why this matters:** Unlabeled feedback is the primary failure mode of multi-LLM review. When everything is a "concern," the human cannot prioritize. The labels make the synthesis actionable.
+
+**Your reading list for this session:**
+1. Your project status doc — see Session Start Protocol below
+2. Your architecture/decisions doc — see Session Start Protocol below (you need this to identify true violations)
+3. `docs/PROPOSAL-FORMAT.md` — the review output format and checklist
+4. The proposal document you are reviewing — read fully before commenting
+
+**Your output format:** Follow the Review section template in `docs/PROPOSAL-FORMAT.md`. Your review becomes Section 2 or Section 3 of the proposal document.
+
+**BLUF — how to communicate with the human:**
+Your review is read by the Author, not directly by the human. Keep each concern to 3 lines: label + what's wrong + suggested fix. No preamble. The label `[V]`, `[T]`, or `[P]` does the prioritization work — don't repeat it in prose.
+
+---
+
+## What This Project Is
+
+<!-- PROJECT-SPECIFIC: Replace this section with a description of your project. Include:
+  - What the project does and who it's for
+  - The core paradigm / architecture style
+  - What the system is made of (modules, services, agents, etc.)
+  - What format the code/config takes (TypeScript classes, YAML files, Python modules, etc.)
+-->
+
+[Describe your project here.]
+
+---
+
+## Session Start Protocol — Do This Every Time
+
+**Before you do any other reading or any work:**
+1. Confirm your role (Author or Reviewer) — see "Step Zero — Know Your Role" above
+2. Then follow the reading list for your role
+
+**If you are doing general repo work (not a proposal), read these files in this order:**
+
+### Step 1 — Read project status (mandatory)
+
+```
+<!-- PROJECT-SPECIFIC: Path to your current-state / project-status doc -->
+```
+
+<!-- PROJECT-SPECIFIC: Describe what this file contains — current sprint, what's done, what's next, key warnings. -->
+
+**Do not assume the repo state from a previous conversation. Always read this file first.**
+
+### Step 2 — Read the architecture document
+
+```
+docs/decisions/ARCHITECTURE.md
+```
+
+<!-- PROJECT-SPECIFIC: Describe what this file contains — key design decisions, patterns, constraints, rationale. -->
+
+Many choices that look like oversights are intentional. The rationale is in this file.
+
+### Step 3 — Read the root README
+
+```
+README.md
+```
+
+<!-- PROJECT-SPECIFIC: Describe what the README covers — full system overview, directory structure, key concepts. -->
+
+### Step 4 — Read the contributing guide (if making or reviewing changes)
+
+```
+<!-- PROJECT-SPECIFIC: Path to your CONTRIBUTING.md or equivalent, if it exists -->
+```
+
+### Step 5 — Read relevant standards (task-specific)
+
+<!-- PROJECT-SPECIFIC: List format specs, schema docs, or standards that apply to specific task types.
+Example format:
+
+| Task | Read This |
+|---|---|
+| Reviewing or creating a [component type] | `path/to/spec.md` |
+| Reviewing or creating a [artifact type] | `path/to/format.md` |
+
+Do not read all standards speculatively — only those relevant to the task at hand.
+-->
+
+---
+
+## Repository Structure
+
+<!-- PROJECT-SPECIFIC: Paste or describe your repo structure here. Update whenever structure changes significantly.
+Example:
+
+```
+your-repo/
+├── docs/
+│   ├── AI-COLLABORATOR-GUIDE.md    ← this file
+│   ├── PROPOSAL-FORMAT.md          ← multi-LLM review workflow spec
+│   ├── decisions/
+│   │   └── ARCHITECTURE.md         ← all design decisions
+│   └── proposals/                  ← PROP-NNN architecture proposal documents
+├── README.md
+└── src/
+    └── ...
+```
+-->
+
+---
+
+## Key Standards and Conventions
+
+<!-- PROJECT-SPECIFIC: Describe your project's core standards and non-negotiable patterns. Examples:
+  - Naming conventions
+  - File structure rules
+  - Schema / format requirements
+  - Testing requirements
+  - "A partial X is an invalid X" type rules
+-->
+
+---
+
+## Platform & Ecosystem Awareness
+
+The system is designed to be vendor, platform, and deployment-model agnostic. However, **"agnostic" means no hard dependencies, not indifferent.** When doing any work that touches integration points — authentication, storage, APIs, output destinations, notification patterns, or user/role management — surface platform compatibility explicitly.
+
+**Full platform tier reference and flagging rules are in `docs/PROPOSAL-FORMAT.md` (Platform & Ecosystem Awareness section).** Summary below for quick reference.
+
+### Tier 1 — Assume present in target customer environments
+
+| Category | Platforms |
+|---|---|
+| Cloud infrastructure | AWS, Microsoft Azure, Google Cloud Platform |
+| Email & productivity | Microsoft 365, Google Workspace |
+| Communications | Slack, Microsoft Teams |
+| CRM | Salesforce, HubSpot CRM |
+| Identity & SSO | Microsoft Entra ID (Azure AD), Okta, Google Identity |
+
+### Tier 2 — Common in 40–60% of target environments
+
+| Category | Platforms |
+|---|---|
+| Marketing automation | HubSpot Marketing Hub, Salesforce Marketing Cloud, Marketo, Pardot |
+| Project management | Asana, Monday.com, Jira |
+| Data warehouse | Snowflake, BigQuery, Redshift, Databricks |
+| Analytics & BI | Looker, Tableau, Power BI |
+| Document collaboration | Notion, Confluence, SharePoint |
+
+### When to flag (quick rule)
+
+Flag if the proposal or design touches: auth/identity, file storage/format, API design, output destinations, webhook/notification patterns, or user/role management.
+
+Do not flag if it involves only internal logic, configuration structure, or content with no external integration surface.
+
+Categorize as `[V]` if a stated requirement is violated, `[T]` for Tier 1 or Tier 2 friction, `[P]` or omit for niche platforms.
+
+---
+
+## Non-Negotiable Rules (Do Not Override)
+
+<!-- PROJECT-SPECIFIC: List your project's intentional architectural or business constraints.
+LLMs must not propose changes that violate these rules.
+Example format:
+
+1. **[Rule name]** — [one sentence description]
+2. **[Rule name]** — [one sentence description]
+-->
+
+---
+
+## Git Conventions
+
+- **Never commit directly to `main`** — all work on feature branches, merged via PR
+- Branch naming: `feat/`, `fix/`, `docs/`
+- Doc changes ship in the same commit as the change that requires them — never a separate follow-up
+
+<!-- PROJECT-SPECIFIC: Add any additional git conventions specific to your project. -->
+
+---
+
+## Architecture Decisions Summary
+
+Full detail in `docs/decisions/ARCHITECTURE.md`.
+
+<!-- PROJECT-SPECIFIC: Add a quick-reference table of key decisions as they accumulate.
+Leave blank initially — populate as decisions are made and recorded.
+
+| Decision | Summary |
+|---|---|
+| D1 | [First key decision] |
+| D2 | [Second key decision] |
+-->
+
+---
+
+## Multi-LLM Architecture Review Workflow
+
+For design proposals and architecture decisions that require multi-model review before the human decides.
+
+**Full spec:** `docs/PROPOSAL-FORMAT.md` — read this before participating in any proposal.
+
+### How the workflow operates
+
+```
+Author writes proposal (Section 1 of proposal doc)
+    ↓
+Reviewer 1 writes review (Section 2)
+    ↓
+Reviewer 2 writes review, if assigned (Section 3)
+    ↓
+Author writes synthesis (Section 4) — organized by topic, not by reviewer
+    ↓
+Human reads Section 4.5 (Decisions Required), makes decisions, asks questions
+    ↓
+Human decisions recorded in Section 5
+    ↓
+Author writes final spec (Section 6)
+    ↓
+Finalized decisions promoted to docs/decisions/ARCHITECTURE.md as new D-numbers
+```
+
+### Where proposals live
+
+All proposals are stored in `docs/proposals/` as single growing documents:
+```
+docs/proposals/
+├── PROP-001-{short-title}.md
+├── PROP-002-{short-title}.md
+└── ...
+```
+
+Check the directory for the highest existing PROP number before creating a new one.
+
+### The most important discipline
+
+**Authors:** The synthesis (Section 4) is not a defense of your proposal. It is a navigation tool for the human. If a reviewer is right, say so and update the proposal. If you disagree, frame it honestly as a decision for the human — not a conclusion you've already reached.
+
+**Reviewers:** Label every concern `[V]`, `[T]`, or `[P]`. No exceptions. Unlabeled feedback cannot be synthesized.
+
+### When a proposal is finalized
+
+The Author adds new design decisions to `docs/decisions/ARCHITECTURE.md` as new D-numbers, with a link back to the proposal as the review trail. Proposals become the permanent record of why decisions were made — not just what was decided.
+
+---
+
+*Last updated: [YYYY-MM-DD] — [brief note on what changed]*

--- a/docs/PROPOSAL-FORMAT.md
+++ b/docs/PROPOSAL-FORMAT.md
@@ -1,0 +1,549 @@
+# PROPOSAL-FORMAT.md — Multi-LLM Architecture Review Workflow
+
+> Spec for design and architecture proposals that are reviewed by multiple AI models before a human makes final decisions. Read this if you are participating in a proposal as either the Primary Author or a Reviewer.
+
+---
+
+## Overview
+
+This workflow enables multiple AI models to collaborate on architecture and design proposals with structured human oversight. The human (HITL — Human In The Loop) makes all final decisions. AI models contribute analysis, challenge assumptions, surface tradeoffs, and synthesize disagreements — but they do not decide.
+
+**The flow:**
+
+```
+Author drafts proposal
+       ↓
+Reviewer 1 produces structured review
+       ↓
+Reviewer 2 produces structured review (optional)
+       ↓
+Author produces synthesis (NOT a defense — a navigation)
+       ↓
+Human reads synthesis, makes decisions, asks follow-up questions
+       ↓
+Author incorporates decisions → Final Specification
+       ↓
+Finalized decisions promoted to docs/decisions/ARCHITECTURE.md as new D-numbers
+```
+
+**All proposals live in `docs/proposals/` as a single growing document.**
+Each proposal is one file: `PROP-{NNN}-{short-title}.md`
+The document grows in sections as each participant contributes.
+
+---
+
+## BLUF Communication Standard
+
+**All human-facing output in this workflow follows BLUF: Bottom Line Up Front.**
+
+The human is not reading at LLM speed. They do not need background, theory, or a recap of the review process. They need the minimum information required to make a decision. If they want more context, they will ask.
+
+**The rule:** Lead with the conclusion. Put reasoning after, not before.
+
+### What this means in practice
+
+**For Section 4.5 (Decisions Required) — the most critical:**
+- State the decision in one sentence
+- List options as single-line bullets
+- Give your recommendation in one line
+- Add one sentence of reasoning — maximum
+- Each decision item must fit in 5 lines or fewer
+- The human must be able to read all of Section 4.5 in under 2 minutes
+
+**For reviews (Sections 2–3):**
+- State each concern in 1–3 sentences: label, what's wrong, suggested fix
+- No preamble. No "I noticed that..." or "Upon reflection..."
+- The label `[V]`, `[T]`, or `[P]` does the categorization work — don't explain the category in prose
+
+**The test:** Read your output. Find the first sentence that actually tells the human something they need to act on. Move that sentence to the top. Delete everything before it.
+
+**Do not:**
+- Summarize the review process before stating decisions
+- Explain why a concern exists before stating the concern
+- Repeat information already present in earlier sections of the document
+- Use more words to signal thoroughness — the structure does that, not the word count
+
+**Do:**
+- State the decision, option, or recommendation first
+- Use the document structure (section numbers, labels, tables) to carry context
+- Trust the human to ask if they need more depth
+
+---
+
+## Platform & Ecosystem Awareness
+
+Most systems are designed to be vendor, platform, model, and deployment-model agnostic. **"Agnostic" means no hard dependencies — it does not mean indifferent.** Proposals that touch integration points must account for the platforms target users actually run.
+
+When a proposal involves authentication, data storage, API design, output formats, notification patterns, or user/role management — surface platform compatibility explicitly. Do not assume agnosticism resolves the question.
+
+### Platform Tiers
+
+**Tier 1 — Assume present in the target customer environment (80%+ penetration)**
+
+| Category | Platforms |
+|---|---|
+| Cloud infrastructure | AWS, Microsoft Azure, Google Cloud Platform |
+| Email & productivity | Microsoft 365 (Exchange, SharePoint, Teams), Google Workspace (Gmail, Drive, Docs) |
+| Communications | Slack, Microsoft Teams |
+| CRM | Salesforce, HubSpot CRM |
+| Identity & SSO | Microsoft Entra ID (Azure AD), Okta, Google Identity |
+
+**Tier 2 — Common in 40–60% of target environments**
+
+| Category | Platforms |
+|---|---|
+| Marketing automation | HubSpot Marketing Hub, Salesforce Marketing Cloud, Marketo (Adobe), Pardot |
+| Project management | Asana, Monday.com, Jira (Atlassian) |
+| Data warehouse | Snowflake, Google BigQuery, Amazon Redshift, Databricks |
+| Analytics & BI | Looker (Google), Tableau (Salesforce), Microsoft Power BI |
+| Document collaboration | Notion, Confluence (Atlassian), SharePoint |
+| File storage | SharePoint, Google Drive, Box, Dropbox |
+
+### When to flag platform compatibility
+
+Only flag when the proposal makes a choice that actually differs between platforms, or where a stated compatibility requirement is at risk. Do not flag platforms speculatively on every proposal.
+
+**Flag when the proposal involves:**
+- **Authentication / identity** — any SSO, RBAC, or access token decision has implications for Entra ID, Okta, and Google Identity (SCIM provisioning, OAuth flows, SAML)
+- **Data storage or file format** — where outputs land (SharePoint vs Google Drive vs S3 vs local) and what format affects downstream usability
+- **API design or integration points** — REST + JSON is the lowest common denominator; flag if a design creates friction with major platform APIs
+- **Output destinations** — if a deliverable is designed to be sent, posted, or synced somewhere, name which platforms must be compatible
+- **Notification or webhook patterns** — Slack and Teams webhooks are near-universal in enterprise; email is always present
+- **User/role management** — decisions about multi-user access should account for SCIM provisioning patterns and enterprise SSO
+
+**Do not flag when:** the proposal involves only internal logic, configuration structure, or content that has no external integration surface.
+
+### How to categorize platform compatibility concerns
+
+| Situation | Label |
+|---|---|
+| Design violates a stated compatibility requirement | `[V]` |
+| Design works but creates meaningful friction with a Tier 1 platform | `[T]` |
+| Design creates friction with a Tier 2 platform | `[T]` — lower priority, note the tier |
+| Design creates friction with a niche or non-standard platform | `[P]` or omit — not worth surfacing |
+
+**The goal is not to design for every platform.** It is to ensure the human understands compatibility tradeoffs for the platforms their users actually run.
+
+---
+
+## The Two Roles
+
+The human will tell you at the start of the session which role you are playing. Your reading list, your output format, your mindset, and your discipline are different depending on the role.
+
+---
+
+### Role 1: Primary Author / Architect
+
+**You are assigned this role when:** the human asks you to write an architecture proposal, design a new component, or draft a spec for review.
+
+**Your job:**
+- Write a complete, clear proposal that reviewers can engage with
+- Be explicit about assumptions and tradeoffs you already see
+- Flag your own open questions proactively — don't hide uncertainty
+- After reviews arrive: synthesize fairly, not defensively
+- Produce a HITL decision summary that genuinely helps the human decide — not one that argues for your position
+
+**What to read before drafting:**
+1. Project status doc (see `docs/AI-COLLABORATOR-GUIDE.md` for path)
+2. `docs/decisions/ARCHITECTURE.md` — all existing decisions
+3. Any standards or format docs relevant to what you're proposing
+4. Any existing proposal documents in `docs/proposals/` that are related
+
+**Mindset:** You have thought about this problem more than anyone else in this conversation. Write with confidence. But when synthesizing reviews, your job is to navigate disagreements honestly — not to win them. If a reviewer is right, say so explicitly and update the proposal. If you disagree, explain why clearly and frame it as a decision for the human, not a judgment call you've already made.
+
+**What "synthesizing fairly" means:**
+- Group by topic/decision area, not by reviewer name
+- For each area: state the question, state all positions with reasoning, state the tradeoff
+- If you agree with a reviewer's point: say "Reviewer X raised this; I agree and the proposal should be updated to..."
+- If you disagree: say "Reviewer X raised this; I disagree because Y. The tradeoff is Z. The human should decide."
+- Never summarize reviewer feedback in a way that makes it sound weaker than it is
+
+**What the synthesis is NOT:**
+- Not a defense of the original proposal
+- Not a recap organized by reviewer ("Reviewer 1 said... Reviewer 2 said...")
+- Not a place to relitigate closed design decisions
+- Not a place to make decisions — surface them for the human
+
+---
+
+### Role 2: Reviewer / Architecture Reviewer
+
+**You are assigned this role when:** the human asks you to review an existing proposal and provide feedback.
+
+**Your job:**
+- Evaluate the proposal against the project's stated requirements and existing architecture decisions
+- Raise concerns that are specific, referenced, and actionable
+- Distinguish between violations, tradeoffs, and preferences (see below)
+- Ask clarifying questions when you genuinely don't understand intent — don't assume bad intent
+
+**What to read before reviewing:**
+1. Project status doc (see `docs/AI-COLLABORATOR-GUIDE.md` for path)
+2. `docs/decisions/ARCHITECTURE.md` — all existing decisions; evaluate the proposal's consistency with them
+3. The proposal document itself — read it fully before writing a single word of review
+4. Any standards or format docs relevant to what's being proposed
+
+**Mindset:** You are evaluating the proposal on its own terms before you evaluate it on yours. A proposal that makes choices you wouldn't have made is not necessarily a bad proposal. Engage with the author's reasoning before proposing alternatives.
+
+**The three-category discipline — every piece of feedback must be categorized:**
+
+| Category | Label | Meaning |
+|---|---|---|
+| **Violation** | `[V]` | This contradicts a stated requirement, an existing architecture decision, or a non-negotiable constraint. It must change. |
+| **Tradeoff** | `[T]` | This is a legitimate design choice, but it has costs that aren't acknowledged. The human should understand the tradeoff before deciding. |
+| **Preference** | `[P]` | I would have approached this differently. This is my opinion, not an objective problem. |
+
+**You must label every substantive concern with `[V]`, `[T]`, or `[P]`.** This is the most important discipline in the entire workflow. Unlabeled concerns make synthesis impossible and waste the human's decision-making time.
+
+**What good reviewer feedback looks like:**
+- Specific: references a section, decision, or specific detail — not "the approach feels off"
+- Actionable: proposes a modification with rationale, or asks a clarifying question
+- Scoped: does not propose a rewrite of the entire proposal; proposes targeted changes
+- Honest about category: does not label preferences as violations
+
+**What reviewers must NOT do:**
+- Propose rewrites — propose specific modifications with rationale
+- Relitigate closed decisions without new information
+- Treat aesthetic disagreement as an architectural concern
+- Label preferences as violations to make them sound more urgent
+
+---
+
+## Document Template
+
+Every proposal document follows this exact structure. Do not add sections. Do not skip sections. Mark sections as `N/A` if genuinely not applicable — do not omit them.
+
+---
+
+```markdown
+# PROP-{NNN}: {Title}
+
+**Status:** Draft | Under Review | Synthesis Ready | Decisions Pending | Finalized | Superseded
+**Phase context:** {brief context — current sprint, milestone, or phase}
+**Related decisions:** {D-numbers from ARCHITECTURE.md, or "None"}
+**Author:** {LLM model name / identifier}
+**Created:** {YYYY-MM-DD}
+**Last updated:** {YYYY-MM-DD}
+**Reviewers:** {LLM model name(s) — filled in as reviews are added}
+
+---
+
+## Section 1 — Proposal
+
+*Written by the Author. Do not edit this section after reviews begin. If you want to update based on review feedback, do it in the Final Specification (Section 6).*
+
+### 1.1 Problem Statement
+
+[What problem is being solved? Why does it need to be solved? Why now?
+Be specific — "the system needs more flexibility" is not a problem statement.]
+
+### 1.2 Proposed Solution
+
+[High-level description of the approach. One paragraph. Details go in 1.3.]
+
+### 1.3 Design Details
+
+[The full specification. Schema changes, file structure, behavioral rules, naming conventions,
+new sections, new fields — whatever is relevant to this proposal.
+Be complete. Reviewers cannot evaluate what isn't written down.]
+
+### 1.4 Alternatives Considered
+
+[What other approaches were evaluated? Why were they rejected?
+If you only considered one approach, say so and explain why alternatives weren't explored.]
+
+### 1.5 Impact Assessment
+
+| Area | Impact |
+|---|---|
+| Existing components | [which parts of the system are affected, and how] |
+| Interfaces / contracts | [API changes, schema changes, breaking contracts?] |
+| Documentation | [which docs need updating] |
+| Migration | [is existing content or data affected? is migration required?] |
+| Breaking changes | [yes/no — what breaks if this is adopted] |
+| Platform compatibility | [which Tier 1/2 platforms are affected and what the compatibility posture is — or "N/A: no external integration surface"] |
+
+### 1.6 Author's Open Questions
+
+[Things you are genuinely uncertain about and want reviewer input on.
+Numbering: AQ1, AQ2, AQ3...]
+
+### 1.7 Success Criteria
+
+[How will we know this proposal is correctly implemented?
+What does "done" look like?]
+
+---
+
+## Section 2 — Review 1
+
+**Reviewer:** {LLM model name / identifier}
+**Date:** {YYYY-MM-DD}
+**Overall assessment:** Approve | Approve with modifications | Needs revision | Reject
+
+*Reviewers: label every concern [V], [T], or [P]. See PROPOSAL-FORMAT.md for definitions.*
+
+### 2.1 Points of Agreement
+
+[What you agree with and why. Be specific — "looks good" is not useful.]
+
+### 2.2 Concerns
+
+[Label each concern [V], [T], or [P] and number them C1, C2, C3...
+3 lines per concern, maximum. No preamble.]
+
+**C1 [V/T/P]:** {what's wrong — one sentence}
+**Ref:** {section number or decision record reference}
+**Fix:** {specific change — one sentence, or "See RQ1" if clarification needed first}
+
+### 2.3 Clarifying Questions
+
+[Things you need clarified before you can fully evaluate.
+Numbering: RQ1, RQ2, RQ3... (Reviewer Questions, distinct from Author Questions AQ1...)]
+
+### 2.4 Reviewer Summary
+
+[2–4 sentences: overall read, most important concern, what would make you change your assessment.]
+
+---
+
+## Section 3 — Review 2 (if applicable)
+
+**Reviewer:** {LLM model name / identifier}
+**Date:** {YYYY-MM-DD}
+**Overall assessment:** Approve | Approve with modifications | Needs revision | Reject
+
+*Same structure as Section 2. Note any points where you agree or disagree with Review 1.*
+
+### 3.1 Points of Agreement
+
+### 3.2 Concerns
+
+### 3.3 Clarifying Questions
+
+### 3.4 Agreement / Disagreement with Review 1
+
+[Where do you agree with Review 1? Where do you see it differently? Be specific.]
+
+### 3.5 Reviewer Summary
+
+---
+
+## Section 4 — Author Synthesis
+
+**Author:** {LLM model name / identifier}
+**Date:** {YYYY-MM-DD}
+
+*Do not organize this section by reviewer. Organize by topic/decision area.
+This section is a navigation tool for the human — not a defense of the proposal.*
+
+### 4.1 Points of Consensus
+
+[What all reviewers agreed on. These are likely safe to proceed with as-is.
+If you agree and are updating the proposal, say so explicitly.]
+
+### 4.2 Points of Divergence
+
+[For each area where reviewers disagreed with each other or with the proposal:]
+
+**Topic: {name}**
+- **Author position:** {your position}
+- **Reviewer position(s):** {what reviewers said, fairly represented}
+- **Tradeoff:** {what is gained and lost by each path}
+- **Author's recommendation:** {what you think is right and why — honest, not defensive}
+- → **Decision required from human:** yes | no (if no, explain why)
+
+[Repeat for each area of divergence]
+
+### 4.3 Author Responses to Reviewer Questions
+
+[Respond to each RQx from the reviews.
+Format: **RQ1 response:** {your answer}]
+
+### 4.4 Proposed Updates to Original Proposal
+
+[List any changes you are making to the proposal based on reviewer feedback.
+These are changes you agree with — not contested points.
+Format: "Updating Section 1.3: {what's changing and why}"]
+
+### 4.5 Decisions Required from Human
+
+*This is the primary output of the synthesis. The human reads this section first.*
+
+**BLUF discipline is mandatory here.** Each decision item must fit in 5 lines or fewer. The human must be able to read all of Section 4.5 in under 2 minutes. No preamble. No recap. State the decision, the options, your recommendation, and stop. If they want background, they will ask.
+
+[Numbered list. Each item is a specific binary or multiple-choice decision.]
+
+**Decision 1: {Title — one line stating what needs to be decided}**
+- **A:** {option} — {one-phrase consequence}
+- **B:** {option} — {one-phrase consequence}
+- **Recommend A** — {one sentence, max}
+
+**Decision 2: {Title}**
+[same format — 5 lines max]
+
+**Clarifications needed (not decisions):**
+[One line per question. No explanation unless the question is ambiguous without it.]
+- {Q1: specific question}
+- {Q2: specific question}
+
+---
+
+## Section 5 — HITL Decision Log
+
+*Filled in by the human (or transcribed from the conversation by the Author).*
+
+**Date:** {YYYY-MM-DD}
+
+### 5.1 Human Decisions
+
+**Decision 1:** {Human's answer — verbatim or close paraphrase}
+**Decision 2:** {Human's answer}
+[...]
+
+### 5.2 Clarifications Provided
+
+[Human's answers to clarification questions from Section 4.5]
+
+### 5.3 Follow-up Discussion
+
+[If the human asked questions or additional discussion was needed before decisions were final,
+summarize the key exchanges here.]
+
+### 5.4 Final Decision Summary
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| 1 | {Option chosen} | {Human's stated reason, or "Per discussion above"} |
+| 2 | {Option chosen} | {Human's stated reason} |
+
+---
+
+## Section 6 — Final Specification
+
+**Status:** Finalized
+**Date:** {YYYY-MM-DD}
+**Author:** {LLM model name / identifier}
+
+*The complete, finalized spec incorporating all decisions from Section 5.
+This is the document that gets implemented. It supersedes Section 1.*
+
+### 6.1 Final Design
+
+[Complete specification, updated to reflect all decisions.]
+
+### 6.2 Impact on ARCHITECTURE.md
+
+[List the new D-numbers that should be added to docs/decisions/ARCHITECTURE.md as a result of this proposal.
+Format:
+**D{NN}: {Decision title}** — {1–2 sentence summary for the ARCHITECTURE.md entry}]
+
+### 6.3 Implementation Checklist
+
+[Everything that needs to happen to implement this proposal, in dependency order.]
+
+- [ ] {Task 1}
+- [ ] {Task 2}
+- [ ] {Task 3}
+
+### 6.4 Files to Create or Modify
+
+| File | Action | Notes |
+|---|---|---|
+| `path/to/file` | Create / Modify / Delete | {what changes} |
+
+```
+
+---
+
+## Status States
+
+| Status | Meaning |
+|---|---|
+| **Draft** | Author has written Section 1. No reviews yet. |
+| **Under Review** | One or more reviews in progress or complete. Author synthesis not yet written. |
+| **Synthesis Ready** | Author has completed Section 4. Human has not yet made decisions. |
+| **Decisions Pending** | Human is engaged, decisions are being made. Section 5 being filled in. |
+| **Finalized** | All decisions made. Section 6 complete. Ready to implement. |
+| **Superseded** | Replaced by a later proposal (link to replacement). |
+
+Update the `**Status:**` field in the document header whenever the status changes.
+
+---
+
+## Filing Conventions
+
+### Numbering
+Proposals are numbered sequentially: `PROP-001`, `PROP-002`, `PROP-003`...
+Check `docs/proposals/` for the highest existing number before creating a new proposal.
+
+### File naming
+`PROP-{NNN}-{short-kebab-case-title}.md`
+
+Examples:
+- `PROP-001-auth-provider-selection.md`
+- `PROP-002-data-storage-schema.md`
+- `PROP-003-api-versioning-strategy.md`
+
+### Location
+All proposal documents live in `docs/proposals/`.
+
+### Cross-referencing
+When a proposal's decision is promoted to `docs/decisions/ARCHITECTURE.md`, add a reference in the proposal document's Section 6.2, and add a footnote in ARCHITECTURE.md:
+
+```
+**D{NN}: {Title}** — {description}
+*Review trail: [PROP-{NNN}](../proposals/PROP-{NNN}-{title}.md)*
+```
+
+---
+
+## Promoting Decisions to ARCHITECTURE.md
+
+When a proposal is Finalized, the Author is responsible for:
+
+1. Adding each new design decision from Section 6.2 to `docs/decisions/ARCHITECTURE.md` as a new D-number entry
+2. Including a "Review trail" link back to the proposal document
+3. Committing the finalized proposal document and ARCHITECTURE.md update together in a single commit
+
+**D-numbers are permanent and sequential.** Never reuse a D-number. Never renumber existing decisions. The next D-number after the current highest is yours.
+
+---
+
+## Quality Checklist for Authors
+
+Before marking a proposal as ready for review:
+
+- [ ] Section 1.1 states a specific problem, not a vague goal
+- [ ] Section 1.3 is complete enough that a reviewer can evaluate it without asking "what do you mean?"
+- [ ] Section 1.4 lists at least one alternative that was considered (even if quickly rejected)
+- [ ] Section 1.5 impact assessment is honest — not minimized
+- [ ] Section 1.5 platform compatibility row is filled in — either named platforms with posture, or "N/A: no external integration surface"
+- [ ] Section 1.6 open questions are genuinely open — not rhetorical
+- [ ] Section 1.7 success criteria are specific enough to verify
+
+Before marking a synthesis as ready for human review:
+
+- [ ] Section 4.5 decisions are framed as options, not as "Reviewer X thinks vs Reviewer Y thinks"
+- [ ] Every decision in 4.5 has a clear "Recommend" with a one-sentence reason
+- [ ] Every decision item in 4.5 is 5 lines or fewer — no exceptions
+- [ ] Section 4.5 can be read in full in under 2 minutes
+- [ ] Reviewer concerns are represented fairly — not softened
+- [ ] Points where author agreed with reviewers are explicitly called out in 4.4
+- [ ] No open reviewer questions (RQx) have been left unanswered in 4.3
+- [ ] No section opens with a preamble — lead with the substance
+
+## Quality Checklist for Reviewers
+
+Before submitting a review:
+
+- [ ] Every concern in Section 2.2 is labeled [V], [T], or [P]
+- [ ] Every concern is 3 lines or fewer (what's wrong / reference / fix)
+- [ ] Every [V] concern cites the specific requirement or decision it violates
+- [ ] Every [P] concern is honest about being a preference — not dressed up as a tradeoff
+- [ ] Suggested modifications are specific changes, not rewrites
+- [ ] Clarifying questions (2.3) are one line each — genuine questions, not rhetorical objections
+- [ ] Platform compatibility has been assessed — Tier 1 friction flagged as [T] or [V] where the proposal has an external integration surface; Tier 2 friction flagged as lower-priority [T]
+
+---
+
+*Last updated: 2026-03-01*

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,21 @@
+# Architecture Proposals
+
+This directory contains multi-LLM architecture review documents for design decisions that require structured review before the human decides.
+
+**Format spec:** See `../PROPOSAL-FORMAT.md` for the complete template, role definitions, and workflow.
+
+## Active Proposals
+
+| ID | Title | Status | Author | Last Updated |
+|---|---|---|---|---|
+| — | *(none yet)* | — | — | — |
+
+## Finalized Proposals
+
+| ID | Title | Decision | ARCHITECTURE.md |
+|---|---|---|---|
+| — | *(none yet)* | — | — |
+
+---
+
+*When adding a proposal: update the Active Proposals table above. When a proposal is finalized: move it to Finalized and link the D-number(s) it generated.*

--- a/onboard.sh
+++ b/onboard.sh
@@ -29,9 +29,22 @@ cp "$STAGING_DIR/.agents/workflows/"* .agents/workflows/
 
 # 4. Setup Project Documentation Structure
 echo "📂 Setting up documentation structure..."
-mkdir -p docs/architecture docs/roadmap docs/decisions
+mkdir -p docs/architecture docs/roadmap docs/decisions docs/proposals docs/guides
 if [ ! -f "docs/README.md" ]; then
     cp "$STAGING_DIR/docs/README.md" docs/README.md
+fi
+
+# 4b. Setup Multi-LLM Review Workflow
+echo "🤝 Setting up multi-LLM review workflow..."
+if [ ! -f "docs/AI-COLLABORATOR-GUIDE.md" ]; then
+    cp "$STAGING_DIR/docs/AI-COLLABORATOR-GUIDE-template.md" docs/AI-COLLABORATOR-GUIDE.md
+    echo "   ✏️  Fill in the [PROJECT-SPECIFIC] sections in docs/AI-COLLABORATOR-GUIDE.md"
+fi
+if [ ! -f "docs/PROPOSAL-FORMAT.md" ]; then
+    cp "$STAGING_DIR/docs/PROPOSAL-FORMAT.md" docs/PROPOSAL-FORMAT.md
+fi
+if [ ! -f "docs/proposals/README.md" ]; then
+    cp "$STAGING_DIR/docs/proposals/README.md" docs/proposals/README.md
 fi
 
 # 5. Initialize Standard Files if missing
@@ -96,4 +109,10 @@ if [ ! -f ".agents/instructions.md" ]; then
 EOL
 fi
 
-echo "✅ Onboarding complete! Machines are now in sync. Tell AntiGravity: 'Onboard this workspace from my blueprint.'"
+echo ""
+echo "✅ Onboarding complete! Machines are now in sync."
+echo ""
+echo "Next steps:"
+echo "  1. Fill in [PROJECT-SPECIFIC] sections in docs/AI-COLLABORATOR-GUIDE.md"
+echo "  2. Update the Quick Start URL in docs/AI-COLLABORATOR-GUIDE.md with your repo path"
+echo "  3. Tell AntiGravity: 'Onboard this workspace from my blueprint.'"


### PR DESCRIPTION
## Summary

Packages the multi-LLM architecture review workflow from the CMO Agent Team into the universal blueprint so every new repo gets it out of the box.

- **`docs/AI-COLLABORATOR-GUIDE-template.md`** — Generic LLM onboarding guide with `[PROJECT-SPECIFIC]` placeholders. Copied to `docs/AI-COLLABORATOR-GUIDE.md` in target repos by `onboard.sh`. Covers: Quick Start (one-URL onboarding), Step Zero role selection (Author / Reviewer), BLUF communication standard, platform & ecosystem awareness, session start protocol, repo structure, non-negotiable rules, git conventions, and the multi-LLM review workflow.

- **`docs/PROPOSAL-FORMAT.md`** — Full HITL review workflow spec. Generic version references `docs/decisions/ARCHITECTURE.md` (consistent with existing blueprint `docs/decisions/` folder). Includes: BLUF standard, platform tier tables + flagging rules, two-role definitions with reading lists, complete PROP-NNN six-section template, status states, filing conventions, decision promotion workflow, and quality checklists for both authors and reviewers.

- **`docs/proposals/README.md`** — Proposal directory index with Active and Finalized tables. Fully generic, no changes needed between projects.

- **`onboard.sh`** — Updated step 4 to also create `docs/proposals/` directory. New step 4b copies all three files into target repos (skips if already present). Post-completion message updated to prompt the human to fill in the `[PROJECT-SPECIFIC]` placeholders and update the Quick Start URL.

## Usage in a new repo

After `onboard.sh` runs:
1. Fill in `[PROJECT-SPECIFIC]` sections in `docs/AI-COLLABORATOR-GUIDE.md`
2. Replace `[YOUR-ORG]/[YOUR-REPO]` in the Quick Start URL
3. Done — the workflow is live

## Test plan

- [ ] Run `onboard.sh` in a fresh repo — confirm all three files are created
- [ ] Run again — confirm existing files are not overwritten
- [ ] Read `docs/AI-COLLABORATOR-GUIDE-template.md` — confirm placeholders are clear and actionable
- [ ] Read `docs/PROPOSAL-FORMAT.md` — confirm template is complete and no CMO-specific references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)