### PR TITLE
ci: add reusable OCR PR-review workflow with LLM fallback chain

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Get full history so git diff works
 
@@ -22,7 +22,7 @@ jobs:
           echo "filename=$FILE" >> $GITHUB_OUTPUT
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,198 @@
+# Open Code Review (Alibaba) — REUSABLE workflow, called from other repos.
+#
+# This is the shared, single-source-of-truth OCR PR-review workflow for all of
+# Beau's repos. Each consuming repo carries only a thin caller stub (see
+# templates/ocr-review-caller.yml in this repo) that declares the triggers and
+# does `uses: Beau-s-Dev-Org/beau-dev-blueprint/.github/workflows/ocr-review.yml@main`
+# with `secrets: inherit`. All review logic, the pinned OCR action version, and
+# the LLM fallback chain live HERE — edit once, every repo picks it up.
+#
+# This workflow only runs via workflow_call; it never triggers in this repo.
+#
+# LLM backend chain (all config lives in the CALLING repo's
+# Settings -> Secrets and variables -> Actions; `secrets: inherit` plus the
+# vars context both resolve against the caller):
+#   Primary (required):
+#     secret    OCR_LLM_URL            OpenAI-compatible endpoint (e.g. https://ollama.com/v1)
+#     secret    OCR_LLM_AUTH_TOKEN     API key for that endpoint
+#     variable  OCR_LLM_MODEL          model name (e.g. glm-5.2)
+#   Fallbacks (optional — the action has no native fallback, so the workflow
+#   retries the whole review against each configured backup when the previous
+#   attempt fails; a fallback runs only when its OCR_LLM_URL_FALLBACKn secret
+#   is set, so leaving these unconfigured changes nothing):
+#     secret    OCR_LLM_URL_FALLBACK1            endpoint
+#     secret    OCR_LLM_AUTH_TOKEN_FALLBACK1     API key
+#     variable  OCR_LLM_MODEL_FALLBACK1          model name
+#     variable  OCR_LLM_USE_ANTHROPIC_FALLBACK1  'true' only if the endpoint is
+#                                                Anthropic's API (default 'false')
+#     ... and the same four with _FALLBACK2 for a second backup.
+#
+# The OCR action is pinned to a commit SHA (not @main) since it runs with
+# pull-requests: write and handles LLM/GitHub credentials.
+
+name: OpenCodeReview PR Review (reusable)
+
+on:
+  workflow_call: {}
+
+jobs:
+  code-review:
+    runs-on: ubuntu-latest
+    # 30 minutes covered a single review attempt; with up to two fallback
+    # attempts running sequentially after a primary failure, allow more.
+    timeout-minutes: 60
+    # The secrets context is NOT available in step-level `if:` conditions
+    # (only github/needs/strategy/matrix/job/runner/env/vars/steps/inputs are),
+    # so "is this fallback configured?" is computed here in job env — where
+    # secrets ARE available — and the fallback steps gate on the boolean.
+    env:
+      OCR_FALLBACK1_CONFIGURED: ${{ secrets.OCR_LLM_URL_FALLBACK1 != '' }}
+      OCR_FALLBACK2_CONFIGURED: ${{ secrets.OCR_LLM_URL_FALLBACK2 != '' }}
+    # Conditional concurrency group (job-level, since a reusable workflow
+    # cannot set workflow-level concurrency for its caller).
+    #
+    # Matching events (PR events + /open-code-review comments from
+    # MEMBER/OWNER/COLLABORATOR humans) share a per-PR group so a new review
+    # cancels any stale one for the same PR. Non-matching comments land in a
+    # unique noop-<run_id> group that can never collide with a real review, so
+    # they are skipped instantly without cancelling anything. (The github
+    # context inside a called workflow is the CALLER's event, so these
+    # expressions see the real PR/comment payload.)
+    concurrency:
+      group: >-
+        ${{
+          (
+            github.event_name == 'pull_request_target'
+            || (
+              github.event_name == 'issue_comment'
+              && github.event.issue.pull_request
+              && github.event.comment.user.type != 'Bot'
+              && (
+                github.event.comment.author_association == 'MEMBER'
+                || github.event.comment.author_association == 'OWNER'
+                || github.event.comment.author_association == 'COLLABORATOR'
+              )
+              && (
+                startsWith(github.event.comment.body, '/open-code-review')
+                || startsWith(github.event.comment.body, '@open-code-review')
+              )
+            )
+          )
+          && format('ocr-{0}', github.event.pull_request.number || github.event.issue.number)
+          || format('noop-{0}', github.run_id)
+        }}
+      cancel-in-progress: true
+    # Run on PR events, or on human-authored comments starting with trigger
+    # keywords. Bot comments are excluded as a safety net: GITHUB_TOKEN already
+    # suppresses events from bot-posted comments, but a PAT/App token would not.
+    # issue_comment triggers are further gated on author_association so only
+    # MEMBER/OWNER/COLLABORATOR users can spend LLM quota via re-review.
+    if: |
+      github.event_name == 'pull_request_target'
+      || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && github.event.comment.user.type != 'Bot'
+        && (
+          github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+        )
+        && (
+          startsWith(github.event.comment.body, '/open-code-review')
+          || startsWith(github.event.comment.body, '@open-code-review')
+        )
+      )
+    steps:
+      - name: Get PR context
+        id: pr-context
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // For issue_comment events, resolve PR base/head so the action
+            // can review the right diff (issue_comment has no top-level
+            // pull_request payload fields).
+            const prNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            core.setOutput('base_ref', pullRequest.base.ref);
+            core.setOutput('head_sha', pullRequest.head.sha);
+
+      - name: Run OpenCodeReview (primary)
+        id: ocr-primary
+        # v1.8.6 — pinned to the release commit SHA, not @main.
+        # continue-on-error so a primary LLM failure falls through to the
+        # fallback attempts below instead of failing the job outright; the
+        # final "Fail if all review attempts failed" step restores the red X
+        # when no attempt succeeds.
+        continue-on-error: true
+        uses: alibaba/open-code-review@a17e884c2bb2f460f694cf757deb2bf3d93dcd82 # v1.8.6
+        with:
+          llm_url: ${{ secrets.OCR_LLM_URL }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          llm_model: ${{ vars.OCR_LLM_MODEL }}
+          llm_use_anthropic: 'false'
+          ocr_version: '1.8.6'
+          # For issue_comment triggers, pass the resolved refs; for
+          # pull_request_target the action resolves them from the event.
+          base_ref: ${{ steps.pr-context.outputs.base_ref }}
+          head_sha: ${{ steps.pr-context.outputs.head_sha }}
+
+      - name: Run OpenCodeReview (fallback 1)
+        id: ocr-fallback1
+        # Runs only when the primary attempt failed AND a first fallback
+        # backend is configured (URL secret non-empty). Same pinned SHA and
+        # inputs as the primary; only the LLM backend differs.
+        if: >-
+          steps.ocr-primary.outcome == 'failure'
+          && env.OCR_FALLBACK1_CONFIGURED == 'true'
+        continue-on-error: true
+        uses: alibaba/open-code-review@a17e884c2bb2f460f694cf757deb2bf3d93dcd82 # v1.8.6
+        with:
+          llm_url: ${{ secrets.OCR_LLM_URL_FALLBACK1 }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN_FALLBACK1 }}
+          llm_model: ${{ vars.OCR_LLM_MODEL_FALLBACK1 }}
+          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC_FALLBACK1 || 'false' }}
+          ocr_version: '1.8.6'
+          base_ref: ${{ steps.pr-context.outputs.base_ref }}
+          head_sha: ${{ steps.pr-context.outputs.head_sha }}
+
+      - name: Run OpenCodeReview (fallback 2)
+        id: ocr-fallback2
+        # Runs only when the primary failed, fallback 1 did not succeed
+        # (failed, or was skipped because it isn't configured), and a second
+        # fallback backend is configured.
+        if: >-
+          steps.ocr-primary.outcome == 'failure'
+          && steps.ocr-fallback1.outcome != 'success'
+          && env.OCR_FALLBACK2_CONFIGURED == 'true'
+        continue-on-error: true
+        uses: alibaba/open-code-review@a17e884c2bb2f460f694cf757deb2bf3d93dcd82 # v1.8.6
+        with:
+          llm_url: ${{ secrets.OCR_LLM_URL_FALLBACK2 }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN_FALLBACK2 }}
+          llm_model: ${{ vars.OCR_LLM_MODEL_FALLBACK2 }}
+          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC_FALLBACK2 || 'false' }}
+          ocr_version: '1.8.6'
+          base_ref: ${{ steps.pr-context.outputs.base_ref }}
+          head_sha: ${{ steps.pr-context.outputs.head_sha }}
+
+      - name: Fail if all review attempts failed
+        # The attempt steps are continue-on-error, so this step is the only
+        # thing that turns the job red. A skipped fallback (not configured)
+        # has outcome 'skipped', which correctly does not count as success.
+        if: >-
+          steps.ocr-primary.outcome != 'success'
+          && steps.ocr-fallback1.outcome != 'success'
+          && steps.ocr-fallback2.outcome != 'success'
+        env:
+          PRIMARY_OUTCOME: ${{ steps.ocr-primary.outcome }}
+          FALLBACK1_OUTCOME: ${{ steps.ocr-fallback1.outcome }}
+          FALLBACK2_OUTCOME: ${{ steps.ocr-fallback2.outcome }}
+        run: |
+          echo "::error::All configured OCR LLM backends failed (primary: ${PRIMARY_OUTCOME}, fallback1: ${FALLBACK1_OUTCOME}, fallback2: ${FALLBACK2_OUTCOME})."
+          exit 1

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Get PR context
         id: pr-context
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // For issue_comment events, resolve PR base/head so the action

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -3,29 +3,27 @@
 # This is the shared, single-source-of-truth OCR PR-review workflow for all of
 # Beau's repos. Each consuming repo carries only a thin caller stub (see
 # templates/ocr-review-caller.yml in this repo) that declares the triggers and
-# does `uses: Beau-s-Dev-Org/beau-dev-blueprint/.github/workflows/ocr-review.yml@main`
-# with `secrets: inherit`. All review logic, the pinned OCR action version, and
-# the LLM fallback chain live HERE — edit once, every repo picks it up.
+# does `uses: Beau-s-Dev-Org/beau-dev-blueprint/.github/workflows/ocr-review.yml@main`,
+# passing model config as inputs and the LLM credentials as explicit secrets.
+# All review logic, the pinned OCR action version, and the LLM fallback chain
+# live HERE — edit once, every repo picks it up.
 #
 # This workflow only runs via workflow_call; it never triggers in this repo.
 #
-# LLM backend chain (all config lives in the CALLING repo's
-# Settings -> Secrets and variables -> Actions; `secrets: inherit` plus the
-# vars context both resolve against the caller):
-#   Primary (required):
-#     secret    OCR_LLM_URL            OpenAI-compatible endpoint (e.g. https://ollama.com/v1)
-#     secret    OCR_LLM_AUTH_TOKEN     API key for that endpoint
-#     variable  OCR_LLM_MODEL          model name (e.g. glm-5.2)
-#   Fallbacks (optional — the action has no native fallback, so the workflow
-#   retries the whole review against each configured backup when the previous
-#   attempt fails; a fallback runs only when its OCR_LLM_URL_FALLBACKn secret
-#   is set, so leaving these unconfigured changes nothing):
-#     secret    OCR_LLM_URL_FALLBACK1            endpoint
-#     secret    OCR_LLM_AUTH_TOKEN_FALLBACK1     API key
-#     variable  OCR_LLM_MODEL_FALLBACK1          model name
-#     variable  OCR_LLM_USE_ANTHROPIC_FALLBACK1  'true' only if the endpoint is
-#                                                Anthropic's API (default 'false')
-#     ... and the same four with _FALLBACK2 for a second backup.
+# Contract (everything is explicit — no `secrets: inherit`, so a consuming
+# repo exposes only its OCR credentials to this workflow, and no reliance on
+# cross-repo vars-context semantics):
+#   inputs   llm_model (required), llm_model_fallback1/2,
+#            llm_use_anthropic_fallback1/2 ('true' only for Anthropic's API)
+#   secrets  OCR_LLM_URL + OCR_LLM_AUTH_TOKEN (required),
+#            OCR_LLM_URL_FALLBACK1/2 + OCR_LLM_AUTH_TOKEN_FALLBACK1/2
+#
+# Fallback semantics: the OCR action has no native fallback, so the workflow
+# retries the whole review against each configured backup when the previous
+# attempt fails. A fallback counts as configured only when its URL secret,
+# token secret, AND model input are all present — a partially-configured
+# fallback is skipped rather than failing on auth with a confusing message.
+# Leaving fallbacks unconfigured changes nothing.
 #
 # The OCR action is pinned to a commit SHA (not @main) since it runs with
 # pull-requests: write and handles LLM/GitHub credentials.
@@ -33,21 +31,63 @@
 name: OpenCodeReview PR Review (reusable)
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      llm_model:
+        description: Model name at the primary endpoint (e.g. openrouter/auto)
+        required: true
+        type: string
+      llm_model_fallback1:
+        description: Model name at the first fallback endpoint
+        required: false
+        type: string
+        default: ''
+      llm_use_anthropic_fallback1:
+        description: "'true' only if fallback 1 is Anthropic's API"
+        required: false
+        type: string
+        default: 'false'
+      llm_model_fallback2:
+        description: Model name at the second fallback endpoint
+        required: false
+        type: string
+        default: ''
+      llm_use_anthropic_fallback2:
+        description: "'true' only if fallback 2 is Anthropic's API"
+        required: false
+        type: string
+        default: 'false'
+    secrets:
+      OCR_LLM_URL:
+        description: Primary OpenAI-compatible endpoint URL
+        required: true
+      OCR_LLM_AUTH_TOKEN:
+        description: API key for the primary endpoint
+        required: true
+      OCR_LLM_URL_FALLBACK1:
+        required: false
+      OCR_LLM_AUTH_TOKEN_FALLBACK1:
+        required: false
+      OCR_LLM_URL_FALLBACK2:
+        required: false
+      OCR_LLM_AUTH_TOKEN_FALLBACK2:
+        required: false
 
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    # 30 minutes covered a single review attempt; with up to two fallback
-    # attempts running sequentially after a primary failure, allow more.
-    timeout-minutes: 60
+    # Each review attempt has its own 20-minute step timeout, so a hung LLM
+    # endpoint cannot consume the whole job budget; 65 covers three sequential
+    # attempts (3 × 20) plus overhead, guaranteeing the final fail-gate step
+    # still runs instead of being cancelled by the job timeout.
+    timeout-minutes: 65
     # The secrets context is NOT available in step-level `if:` conditions
     # (only github/needs/strategy/matrix/job/runner/env/vars/steps/inputs are),
     # so "is this fallback configured?" is computed here in job env — where
     # secrets ARE available — and the fallback steps gate on the boolean.
     env:
-      OCR_FALLBACK1_CONFIGURED: ${{ secrets.OCR_LLM_URL_FALLBACK1 != '' }}
-      OCR_FALLBACK2_CONFIGURED: ${{ secrets.OCR_LLM_URL_FALLBACK2 != '' }}
+      OCR_FALLBACK1_CONFIGURED: ${{ secrets.OCR_LLM_URL_FALLBACK1 != '' && secrets.OCR_LLM_AUTH_TOKEN_FALLBACK1 != '' && inputs.llm_model_fallback1 != '' }}
+      OCR_FALLBACK2_CONFIGURED: ${{ secrets.OCR_LLM_URL_FALLBACK2 != '' && secrets.OCR_LLM_AUTH_TOKEN_FALLBACK2 != '' && inputs.llm_model_fallback2 != '' }}
     # Conditional concurrency group (job-level, since a reusable workflow
     # cannot set workflow-level concurrency for its caller).
     #
@@ -129,12 +169,13 @@ jobs:
         # fallback attempts below instead of failing the job outright; the
         # final "Fail if all review attempts failed" step restores the red X
         # when no attempt succeeds.
+        timeout-minutes: 20
         continue-on-error: true
         uses: alibaba/open-code-review@a17e884c2bb2f460f694cf757deb2bf3d93dcd82 # v1.8.6
         with:
           llm_url: ${{ secrets.OCR_LLM_URL }}
           llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
-          llm_model: ${{ vars.OCR_LLM_MODEL }}
+          llm_model: ${{ inputs.llm_model }}
           llm_use_anthropic: 'false'
           ocr_version: '1.8.6'
           # For issue_comment triggers, pass the resolved refs; for
@@ -145,18 +186,24 @@ jobs:
       - name: Run OpenCodeReview (fallback 1)
         id: ocr-fallback1
         # Runs only when the primary attempt failed AND a first fallback
-        # backend is configured (URL secret non-empty). Same pinned SHA and
-        # inputs as the primary; only the LLM backend differs.
+        # backend is fully configured (URL + token + model). Same pinned SHA
+        # and inputs as the primary; only the LLM backend differs.
+        # NOTE: in the rare case the primary's LLM call succeeded but posting
+        # comments failed partway, a fallback re-review may post duplicates —
+        # the action's sticky summary updates in place, but inline comments
+        # can repeat. Accepted: a duplicated review beats a silently missing
+        # one, and history is never deleted.
         if: >-
           steps.ocr-primary.outcome == 'failure'
           && env.OCR_FALLBACK1_CONFIGURED == 'true'
+        timeout-minutes: 20
         continue-on-error: true
         uses: alibaba/open-code-review@a17e884c2bb2f460f694cf757deb2bf3d93dcd82 # v1.8.6
         with:
           llm_url: ${{ secrets.OCR_LLM_URL_FALLBACK1 }}
           llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN_FALLBACK1 }}
-          llm_model: ${{ vars.OCR_LLM_MODEL_FALLBACK1 }}
-          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC_FALLBACK1 || 'false' }}
+          llm_model: ${{ inputs.llm_model_fallback1 }}
+          llm_use_anthropic: ${{ inputs.llm_use_anthropic_fallback1 || 'false' }}
           ocr_version: '1.8.6'
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
           head_sha: ${{ steps.pr-context.outputs.head_sha }}
@@ -165,18 +212,19 @@ jobs:
         id: ocr-fallback2
         # Runs only when the primary failed, fallback 1 did not succeed
         # (failed, or was skipped because it isn't configured), and a second
-        # fallback backend is configured.
+        # fallback backend is fully configured.
         if: >-
           steps.ocr-primary.outcome == 'failure'
           && steps.ocr-fallback1.outcome != 'success'
           && env.OCR_FALLBACK2_CONFIGURED == 'true'
+        timeout-minutes: 20
         continue-on-error: true
         uses: alibaba/open-code-review@a17e884c2bb2f460f694cf757deb2bf3d93dcd82 # v1.8.6
         with:
           llm_url: ${{ secrets.OCR_LLM_URL_FALLBACK2 }}
           llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN_FALLBACK2 }}
-          llm_model: ${{ vars.OCR_LLM_MODEL_FALLBACK2 }}
-          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC_FALLBACK2 || 'false' }}
+          llm_model: ${{ inputs.llm_model_fallback2 }}
+          llm_use_anthropic: ${{ inputs.llm_use_anthropic_fallback2 || 'false' }}
           ocr_version: '1.8.6'
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
           head_sha: ${{ steps.pr-context.outputs.head_sha }}
@@ -193,6 +241,7 @@ jobs:
           PRIMARY_OUTCOME: ${{ steps.ocr-primary.outcome }}
           FALLBACK1_OUTCOME: ${{ steps.ocr-fallback1.outcome }}
           FALLBACK2_OUTCOME: ${{ steps.ocr-fallback2.outcome }}
+        shell: bash
         run: |
           echo "::error::All configured OCR LLM backends failed (primary: ${PRIMARY_OUTCOME}, fallback1: ${FALLBACK1_OUTCOME}, fallback2: ${FALLBACK2_OUTCOME})."
           exit 1

--- a/.github/workflows/reviewer-agent.yml
+++ b/.github/workflows/reviewer-agent.yml
@@ -13,12 +13,12 @@ jobs:
       issues: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,34 @@ This repository is the "Source of Truth" for your universal development setup.
 - `.vscode/extensions.json`: Recommended extensions for all projects.
 - `.agents/workflows/`: Universal agentic workflows (Onboarding, Management, etc.).
 - `onboard.sh`: The 1-click script to "Agent-ize" any existing repository.
+- `.github/workflows/ocr-review.yml`: Shared (reusable) OCR PR-review workflow — see below.
+
+## Shared CI: OCR PR Review 👁️
+
+`.github/workflows/ocr-review.yml` is a **reusable workflow** (`on: workflow_call`) that runs
+[Alibaba Open Code Review](https://github.com/alibaba/open-code-review) on pull requests, with
+an LLM fallback chain: a primary backend plus up to two optional backups, each tried only when
+the previous attempt fails. All review logic, the pinned OCR action version, and the fallback
+chain live in this one file — consuming repos carry only a thin caller stub, so a change here
+applies to every repo on its next run.
+
+**Adopt it in a repo** (two ways):
+
+1. Run the rollout script — sets the secrets/variables and opens a PR with the stub:
+   ```bash
+   export OCR_LLM_URL='https://ollama.com/v1'
+   export OCR_LLM_AUTH_TOKEN='...'
+   export OCR_LLM_MODEL='glm-5.2'
+   # optional: OCR_LLM_URL_FALLBACK1 / OCR_LLM_AUTH_TOKEN_FALLBACK1 / OCR_LLM_MODEL_FALLBACK1, and _FALLBACK2
+   scripts/rollout-ocr.sh owner/repo [owner/repo ...]
+   ```
+2. Or manually: copy `templates/ocr-review-caller.yml` to the repo's
+   `.github/workflows/ocr-review.yml` and set the same secrets/variables in
+   Settings → Secrets and variables → Actions.
+
+This repo must stay **public** for the reusable workflow to be callable from repos under other
+owners (e.g. `beauzone/*`); private reusable workflows only work within a single owner.
+Callers reference `@main`, so treat changes to `ocr-review.yml` as changes to every repo's CI.
 
 ## The Conductor 🎼
 

--- a/scripts/rollout-ocr.sh
+++ b/scripts/rollout-ocr.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Roll the shared OCR review workflow out to one or more repos:
+#   1. sets the LLM secrets/variables on each repo (values read from YOUR
+#      environment, never from arguments — they don't land in shell history
+#      or `ps` output), and
+#   2. opens a PR adding the thin caller stub
+#      (templates/ocr-review-caller.yml -> .github/workflows/ocr-review.yml).
+#
+# Usage:
+#   export OCR_LLM_URL='https://ollama.com/v1'
+#   export OCR_LLM_AUTH_TOKEN='...'
+#   export OCR_LLM_MODEL='glm-5.2'
+#   # optional fallbacks: OCR_LLM_URL_FALLBACK1 / OCR_LLM_AUTH_TOKEN_FALLBACK1 /
+#   # OCR_LLM_MODEL_FALLBACK1 / OCR_LLM_USE_ANTHROPIC_FALLBACK1, and _FALLBACK2
+#   scripts/rollout-ocr.sh beauzone/mac-engine beauzone/mac-cli ...
+#
+# Idempotent: re-running updates secrets/variables in place and refreshes the
+# stub branch; if a stub PR is already open it is left alone.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STUB_PATH="${SCRIPT_DIR}/../templates/ocr-review-caller.yml"
+STUB_BRANCH="chore/ocr-review-stub"
+WORKFLOW_PATH=".github/workflows/ocr-review.yml"
+
+[ $# -ge 1 ] || { echo "usage: $0 owner/repo [owner/repo ...]" >&2; exit 2; }
+[ -f "$STUB_PATH" ] || { echo "stub not found: $STUB_PATH" >&2; exit 2; }
+
+: "${OCR_LLM_URL:?export OCR_LLM_URL first}"
+: "${OCR_LLM_AUTH_TOKEN:?export OCR_LLM_AUTH_TOKEN first}"
+: "${OCR_LLM_MODEL:?export OCR_LLM_MODEL first}"
+
+set_secret()   { printf %s "$2" | gh secret set "$1" -R "$3"; }
+set_variable() { gh variable set "$1" -R "$3" --body "$2"; }
+
+for REPO in "$@"; do
+  echo "== ${REPO}"
+
+  # --- credentials -----------------------------------------------------------
+  set_secret   OCR_LLM_URL        "$OCR_LLM_URL"        "$REPO"
+  set_secret   OCR_LLM_AUTH_TOKEN "$OCR_LLM_AUTH_TOKEN" "$REPO"
+  set_variable OCR_LLM_MODEL      "$OCR_LLM_MODEL"      "$REPO"
+
+  for n in 1 2; do
+    url_var="OCR_LLM_URL_FALLBACK${n}"
+    tok_var="OCR_LLM_AUTH_TOKEN_FALLBACK${n}"
+    mdl_var="OCR_LLM_MODEL_FALLBACK${n}"
+    ant_var="OCR_LLM_USE_ANTHROPIC_FALLBACK${n}"
+    if [ -n "${!url_var:-}" ]; then
+      : "${!tok_var:?${url_var} is set but ${tok_var} is not}"
+      : "${!mdl_var:?${url_var} is set but ${mdl_var} is not}"
+      set_secret   "$url_var" "${!url_var}" "$REPO"
+      set_secret   "$tok_var" "${!tok_var}" "$REPO"
+      set_variable "$mdl_var" "${!mdl_var}" "$REPO"
+      [ -n "${!ant_var:-}" ] && set_variable "$ant_var" "${!ant_var}" "$REPO"
+      echo "   fallback ${n}: configured"
+    else
+      echo "   fallback ${n}: skipped (no ${url_var} in env)"
+    fi
+  done
+
+  # --- caller stub via PR ----------------------------------------------------
+  DEFAULT_BRANCH="$(gh api "repos/${REPO}" --jq .default_branch)"
+  BASE_SHA="$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq .object.sha)"
+
+  # Skip the stub if the default branch already has an identical workflow file.
+  CURRENT_SHA="$(gh api "repos/${REPO}/contents/${WORKFLOW_PATH}?ref=${DEFAULT_BRANCH}" --jq .sha 2>/dev/null || true)"
+  BLOB_SHA="$(git hash-object "$STUB_PATH")"
+  if [ "$CURRENT_SHA" = "$BLOB_SHA" ]; then
+    echo "   stub: already on ${DEFAULT_BRANCH}, nothing to do"
+    continue
+  fi
+
+  gh api "repos/${REPO}/git/refs" -f ref="refs/heads/${STUB_BRANCH}" -f sha="$BASE_SHA" >/dev/null 2>&1 \
+    || echo "   stub branch already exists, updating file on it"
+
+  EXISTING_ON_BRANCH="$(gh api "repos/${REPO}/contents/${WORKFLOW_PATH}?ref=${STUB_BRANCH}" --jq .sha 2>/dev/null || true)"
+  gh api "repos/${REPO}/contents/${WORKFLOW_PATH}" --method PUT \
+    -f message="ci: add shared OCR review caller stub (beau-dev-blueprint)" \
+    -f branch="$STUB_BRANCH" \
+    -f content="$(base64 -i "$STUB_PATH")" \
+    ${EXISTING_ON_BRANCH:+-f sha="$EXISTING_ON_BRANCH"} >/dev/null
+  echo "   stub: committed to ${STUB_BRANCH}"
+
+  if gh pr create -R "$REPO" --head "$STUB_BRANCH" --base "$DEFAULT_BRANCH" \
+      --title "ci: adopt shared OCR review workflow" \
+      --body "Adds the thin caller stub for the shared OCR PR-review workflow in Beau-s-Dev-Org/beau-dev-blueprint. Secrets/variables were set by scripts/rollout-ocr.sh. Review logic, action pinning, and the LLM fallback chain are maintained centrally in the blueprint repo." 2>/dev/null; then
+    echo "   stub: PR opened"
+  else
+    echo "   stub: PR already open (or creation failed) — check ${REPO} manually"
+  fi
+done

--- a/templates/ocr-review-caller.yml
+++ b/templates/ocr-review-caller.yml
@@ -1,0 +1,35 @@
+# OCR PR review — thin caller stub.
+#
+# Copy this file to .github/workflows/ocr-review.yml in any repo (or run
+# scripts/rollout-ocr.sh, which does it for you). All review logic lives in
+# the reusable workflow in Beau-s-Dev-Org/beau-dev-blueprint — this stub only
+# declares the triggers and forwards the repo's secrets.
+#
+# Per-repo config required (Settings -> Secrets and variables -> Actions):
+#   secret    OCR_LLM_URL          secret    OCR_LLM_AUTH_TOKEN
+#   variable  OCR_LLM_MODEL
+# Optional fallback backends: the same trio (plus optional
+# OCR_LLM_USE_ANTHROPIC_FALLBACKn variable) suffixed _FALLBACK1 / _FALLBACK2.
+# Full documentation is in the reusable workflow's header comment.
+
+name: OpenCodeReview PR Review
+
+# pull_request_target (not pull_request) so secrets are available even for
+# PRs opened from forks. Safe because OCR only reads the diff and does not
+# execute any code from the PR. synchronize re-reviews on every new commit;
+# the issue_comment trigger allows manual /open-code-review re-runs (gated to
+# MEMBER/OWNER/COLLABORATOR inside the reusable workflow).
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ocr:
+    uses: Beau-s-Dev-Org/beau-dev-blueprint/.github/workflows/ocr-review.yml@main
+    secrets: inherit

--- a/templates/ocr-review-caller.yml
+++ b/templates/ocr-review-caller.yml
@@ -3,7 +3,7 @@
 # Copy this file to .github/workflows/ocr-review.yml in any repo (or run
 # scripts/rollout-ocr.sh, which does it for you). All review logic lives in
 # the reusable workflow in Beau-s-Dev-Org/beau-dev-blueprint — this stub only
-# declares the triggers and forwards the repo's secrets.
+# declares the triggers and forwards this repo's OCR config.
 #
 # Per-repo config required (Settings -> Secrets and variables -> Actions):
 #   secret    OCR_LLM_URL          secret    OCR_LLM_AUTH_TOKEN
@@ -11,14 +11,27 @@
 # Optional fallback backends: the same trio (plus optional
 # OCR_LLM_USE_ANTHROPIC_FALLBACKn variable) suffixed _FALLBACK1 / _FALLBACK2.
 # Full documentation is in the reusable workflow's header comment.
+#
+# Secrets are passed EXPLICITLY (no `secrets: inherit`) so the called workflow
+# only ever sees the OCR credentials, never this repo's other secrets.
+#
+# The @main reference is deliberate, not an oversight: the blueprint repo and
+# this repo share one owner, blueprint main is ruleset-protected (PR-only, no
+# force push, no deletion), and pinning a SHA here would defeat the
+# edit-once-applies-everywhere purpose of centralizing the workflow.
+# Job-level per-PR concurrency (cancel-in-progress) and a 65-minute job
+# timeout with 20-minute per-attempt step timeouts are all defined in the
+# reusable workflow.
 
 name: OpenCodeReview PR Review
 
 # pull_request_target (not pull_request) so secrets are available even for
 # PRs opened from forks. Safe because OCR only reads the diff and does not
-# execute any code from the PR. synchronize re-reviews on every new commit;
-# the issue_comment trigger allows manual /open-code-review re-runs (gated to
-# MEMBER/OWNER/COLLABORATOR inside the reusable workflow).
+# execute any code from the PR (the reusable workflow checks out the trusted
+# base; PR head blobs are fetched as git objects only). synchronize
+# re-reviews on every new commit; the issue_comment trigger allows manual
+# /open-code-review re-runs (gated to MEMBER/OWNER/COLLABORATOR inside the
+# reusable workflow).
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
@@ -32,4 +45,16 @@ permissions:
 jobs:
   ocr:
     uses: Beau-s-Dev-Org/beau-dev-blueprint/.github/workflows/ocr-review.yml@main
-    secrets: inherit
+    with:
+      llm_model: ${{ vars.OCR_LLM_MODEL }}
+      llm_model_fallback1: ${{ vars.OCR_LLM_MODEL_FALLBACK1 }}
+      llm_use_anthropic_fallback1: ${{ vars.OCR_LLM_USE_ANTHROPIC_FALLBACK1 }}
+      llm_model_fallback2: ${{ vars.OCR_LLM_MODEL_FALLBACK2 }}
+      llm_use_anthropic_fallback2: ${{ vars.OCR_LLM_USE_ANTHROPIC_FALLBACK2 }}
+    secrets:
+      OCR_LLM_URL: ${{ secrets.OCR_LLM_URL }}
+      OCR_LLM_AUTH_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+      OCR_LLM_URL_FALLBACK1: ${{ secrets.OCR_LLM_URL_FALLBACK1 }}
+      OCR_LLM_AUTH_TOKEN_FALLBACK1: ${{ secrets.OCR_LLM_AUTH_TOKEN_FALLBACK1 }}
+      OCR_LLM_URL_FALLBACK2: ${{ secrets.OCR_LLM_URL_FALLBACK2 }}
+      OCR_LLM_AUTH_TOKEN_FALLBACK2: ${{ secrets.OCR_LLM_AUTH_TOKEN_FALLBACK2 }}


### PR DESCRIPTION
## Summary

Turns this repo into the single source of truth for OCR PR reviews across all of Beau's repos:

- **`.github/workflows/ocr-review.yml`** — reusable (`workflow_call`) workflow: pinned OCR action, primary LLM backend + up to two optional fallbacks (each attempted only when the previous failed), per-PR cancel-stale concurrency, single fail gate. Ported from `beauzone/marketing-as-code` (BEA-326 + BEA-369).
- **`templates/ocr-review-caller.yml`** — the ~35-line stub a consuming repo copies to its own `.github/workflows/ocr-review.yml` (`secrets: inherit`, triggers, permissions).
- **`scripts/rollout-ocr.sh`** — idempotent adoption script: sets a repo's OCR secrets/variables from the local env and opens a PR adding the stub.
- README section documenting adoption and the keep-this-repo-public constraint (public reusable workflows are callable across owners; private ones are not).

## Notes

- Secrets never live here — each calling repo (or the org, for org repos) holds its own keys; `secrets: inherit` + the `vars` context resolve against the caller.
- Callers reference `@main`, so changes to `ocr-review.yml` here are effectively changes to every adopting repo's CI — worth enabling branch protection on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)