### PR TITLE
fix: pin consuming stubs to a blueprint commit SHA, not @main

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ applies to every repo on its next run.
 
 **Adopt it in a repo** (two ways):
 
-1. Run the rollout script — sets the secrets/variables and opens a PR with the stub:
+The stub pins the reusable workflow to a **full commit SHA**, never `@main`: the called
+workflow receives LLM credentials and runs with `pull-requests: write`, so a mutable branch
+reference would let a push here change privileged code in every consuming repo with no review
+there (BEA-381; the tj-actions/changed-files precedent). Centralized updates survive the pin
+because re-stamping every repo is one command — re-run the rollout script after merging a
+blueprint change, optionally with `BLUEPRINT_REF=<sha-or-tag>`.
+
+1. Run the rollout script — resolves the pin, sets the secrets/variables, and opens a PR with the stub:
    ```bash
    export OCR_LLM_URL='https://ollama.com/v1'
    export OCR_LLM_AUTH_TOKEN='...'

--- a/scripts/rollout-ocr.sh
+++ b/scripts/rollout-ocr.sh
@@ -54,9 +54,21 @@ fi
 
 STUB_RENDERED="$(mktemp)"
 trap 'rm -f "$STUB_RENDERED"' EXIT
-sed -E "s|(ocr-review\.yml)@[0-9a-fA-F]{40}.*$|\1@${BLUEPRINT_SHA}  # ${BLUEPRINT_LABEL}|" \
+# Substitute the pin AND drop the manual-copy NOTE. That note tells a human the
+# SHA is a placeholder, which is true of the template and false of every
+# stamped stub — leaving it in shipped a comment that contradicted the line
+# below it, and a reviewer reading the stub cannot tell a real pin from an
+# unstamped one (three OCR findings across two repos said exactly that).
+sed -E \
+  -e "s|(ocr-review\.yml)@[0-9a-fA-F]{40}.*$|\1@${BLUEPRINT_SHA}  # ${BLUEPRINT_LABEL}|" \
+  -e '/^# NOTE for manual copies:/,/^# keeping the trailing/d' \
   "$STUB_PATH" > "$STUB_RENDERED"
 grep -q "@${BLUEPRINT_SHA}" "$STUB_RENDERED" || { echo "stub pin substitution failed" >&2; exit 1; }
+grep -q 'NOTE for manual copies' "$STUB_RENDERED" && { echo "manual-copy note survived stamping" >&2; exit 1; }
+# The pin is only protective if it names a real commit; a typo'd or stale SHA
+# fails at workflow-load time, silently removing the review gate.
+gh api "repos/${BLUEPRINT_REPO}/commits/${BLUEPRINT_SHA}" --jq .sha >/dev/null \
+  || { echo "pinned SHA ${BLUEPRINT_SHA} does not resolve in ${BLUEPRINT_REPO}" >&2; exit 1; }
 echo "pinning stubs to ${BLUEPRINT_REPO}@${BLUEPRINT_SHA} (${BLUEPRINT_LABEL})"
 STUB_PATH="$STUB_RENDERED"
 

--- a/scripts/rollout-ocr.sh
+++ b/scripts/rollout-ocr.sh
@@ -23,6 +23,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STUB_PATH="${SCRIPT_DIR}/../templates/ocr-review-caller.yml"
 STUB_BRANCH="chore/ocr-review-stub"
 WORKFLOW_PATH=".github/workflows/ocr-review.yml"
+BLUEPRINT_REPO="Beau-s-Dev-Org/beau-dev-blueprint"
+# Which blueprint commit the stubs pin to. Override to roll out a specific
+# reviewed commit; defaults to the current tip of the blueprint's default
+# branch. Re-running the script with a newer ref is how a blueprint change
+# propagates — the pin is what keeps that propagation reviewed rather than
+# automatic (BEA-381).
+BLUEPRINT_REF="${BLUEPRINT_REF:-main}"
 
 [ $# -ge 1 ] || { echo "usage: $0 owner/repo [owner/repo ...]" >&2; exit 2; }
 [ -f "$STUB_PATH" ] || { echo "stub not found: $STUB_PATH" >&2; exit 2; }
@@ -30,6 +37,28 @@ WORKFLOW_PATH=".github/workflows/ocr-review.yml"
 : "${OCR_LLM_URL:?export OCR_LLM_URL first}"
 : "${OCR_LLM_AUTH_TOKEN:?export OCR_LLM_AUTH_TOKEN first}"
 : "${OCR_LLM_MODEL:?export OCR_LLM_MODEL first}"
+
+# Resolve the blueprint ref to an immutable SHA and stamp it into the stub.
+# Consuming repos must never carry a mutable @branch reference: the called
+# workflow receives LLM credentials and runs with pull-requests: write.
+BLUEPRINT_SHA="$(gh api "repos/${BLUEPRINT_REPO}/commits/${BLUEPRINT_REF}" --jq .sha)"
+[ ${#BLUEPRINT_SHA} -eq 40 ] || { echo "could not resolve ${BLUEPRINT_REF} to a full SHA" >&2; exit 1; }
+# Human-readable trailing comment: the tag pointing at this commit if there is
+# one, else the commit's own date. Consumers' pinning guards require a
+# `# <version-or-date>` comment so a wall of hex stays reviewable.
+BLUEPRINT_LABEL="$(gh api "repos/${BLUEPRINT_REPO}/tags" --jq \
+  --arg sha "$BLUEPRINT_SHA" 'map(select(.commit.sha == $sha)) | .[0].name // empty' 2>/dev/null || true)"
+if [ -z "$BLUEPRINT_LABEL" ]; then
+  BLUEPRINT_LABEL="$(gh api "repos/${BLUEPRINT_REPO}/commits/${BLUEPRINT_SHA}" --jq '.commit.committer.date[0:10]')"
+fi
+
+STUB_RENDERED="$(mktemp)"
+trap 'rm -f "$STUB_RENDERED"' EXIT
+sed -E "s|(ocr-review\.yml)@[0-9a-fA-F]{40}.*$|\1@${BLUEPRINT_SHA}  # ${BLUEPRINT_LABEL}|" \
+  "$STUB_PATH" > "$STUB_RENDERED"
+grep -q "@${BLUEPRINT_SHA}" "$STUB_RENDERED" || { echo "stub pin substitution failed" >&2; exit 1; }
+echo "pinning stubs to ${BLUEPRINT_REPO}@${BLUEPRINT_SHA} (${BLUEPRINT_LABEL})"
+STUB_PATH="$STUB_RENDERED"
 
 set_secret()   { printf %s "$2" | gh secret set "$1" -R "$3"; }
 set_variable() { gh variable set "$1" -R "$3" --body "$2"; }

--- a/templates/ocr-review-caller.yml
+++ b/templates/ocr-review-caller.yml
@@ -15,13 +15,22 @@
 # Secrets are passed EXPLICITLY (no `secrets: inherit`) so the called workflow
 # only ever sees the OCR credentials, never this repo's other secrets.
 #
-# The @main reference is deliberate, not an oversight: the blueprint repo and
-# this repo share one owner, blueprint main is ruleset-protected (PR-only, no
-# force push, no deletion), and pinning a SHA here would defeat the
-# edit-once-applies-everywhere purpose of centralizing the workflow.
+# The reusable workflow is pinned to a full commit SHA, not @main: a branch is
+# a mutable pointer, and this job forwards LLM credentials while holding
+# pull-requests: write, so a push to blueprint main would otherwise change
+# privileged code running here with no review in this repo (the BEA-381
+# rationale, and the tj-actions/changed-files precedent). Centralized updates
+# survive the pin because re-stamping every consuming repo is one command:
+# scripts/rollout-ocr.sh resolves the blueprint ref and rewrites this line.
+#
 # Job-level per-PR concurrency (cancel-in-progress) and a 65-minute job
 # timeout with 20-minute per-attempt step timeouts are all defined in the
 # reusable workflow.
+#
+# NOTE for manual copies: the SHA below is a placeholder. Either run
+# scripts/rollout-ocr.sh (which substitutes the real pin), or replace it with
+#   gh api repos/Beau-s-Dev-Org/beau-dev-blueprint/commits/main --jq .sha
+# keeping the trailing `# <version-or-date>` comment.
 
 name: OpenCodeReview PR Review
 
@@ -44,7 +53,7 @@ permissions:
 
 jobs:
   ocr:
-    uses: Beau-s-Dev-Org/beau-dev-blueprint/.github/workflows/ocr-review.yml@main
+    uses: Beau-s-Dev-Org/beau-dev-blueprint/.github/workflows/ocr-review.yml@0000000000000000000000000000000000000000  # 0000-00-00 placeholder — see NOTE above
     with:
       llm_model: ${{ vars.OCR_LLM_MODEL }}
       llm_model_fallback1: ${{ vars.OCR_LLM_MODEL_FALLBACK1 }}


### PR DESCRIPTION
Follow-up to #32 (this commit was pushed after that PR merged, so it needs its own).

mac-engine and mac-mcp-server both landed BEA-381 action-pinning guards whose `_iter_action_refs` explicitly covers reusable-workflow `uses:` references — so a stub carrying `@main` fails their test suites. Their position is right: the called workflow receives LLM credentials and runs with `pull-requests: write`, so a mutable ref lets a push here change privileged code in every consumer with no review there.

- `scripts/rollout-ocr.sh` resolves `BLUEPRINT_REF` (default `main`) to a full commit SHA, derives a version/date label, and stamps `uses: ...@<40-hex>  # <label>` into the stub before committing; it aborts if the substitution does not take.
- The template ships an obvious placeholder SHA plus manual-copy instructions, so a hand-copied stub cannot silently carry a mutable ref.
- README documents the pin and the one-command update path.

All four `beauzone/mac-*` stub PRs have been re-stamped to `f77cc2fe` (blueprint main at 2026-08-15) and now pass both guards. Note `marketing-as-code` deliberately exempts this reference in its own guard and stays on `@main` — an inconsistency flagged for a human decision, not resolved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)