### PR TITLE
fix: completed fallback reviews no longer fail on the artifact-name 409

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -25,6 +25,17 @@
 # fallback is skipped rather than failing on auth with a confusing message.
 # Leaving fallbacks unconfigured changes nothing.
 #
+# Fallback attempts set upload_artifacts: 'false'. The action names its
+# artifact ocr-review-result-<run_id>-<run_attempt>; a fallback runs in the
+# SAME job as the failed primary, so both attempts compute the same name and
+# the fallback's upload 409s ("artifact with this name already exists") —
+# which failed the whole composite AFTER a completed review, so a fully
+# successful fallback review still read as a failed attempt: the gate turned
+# the job red and the computed comments were never posted (observed live on
+# marketing-as-code PR #302 during the 2026-08-20 primary-provider outage).
+# The fallback's result JSON is still printed to the job log by the action;
+# only the downloadable artifact is given up, and only on the fallback path.
+#
 # The OCR action is pinned to a commit SHA (not @main) since it runs with
 # pull-requests: write and handles LLM/GitHub credentials.
 
@@ -205,6 +216,11 @@ jobs:
           llm_model: ${{ inputs.llm_model_fallback1 }}
           llm_use_anthropic: ${{ inputs.llm_use_anthropic_fallback1 || 'false' }}
           ocr_version: '1.8.6'
+          # See the fallback-semantics note in the header: the primary
+          # attempt already uploaded ocr-review-result-<run_id>-<attempt>,
+          # and a second upload under the same name 409s and fails the
+          # composite after a COMPLETED review.
+          upload_artifacts: 'false'
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
           head_sha: ${{ steps.pr-context.outputs.head_sha }}
 
@@ -226,6 +242,8 @@ jobs:
           llm_model: ${{ inputs.llm_model_fallback2 }}
           llm_use_anthropic: ${{ inputs.llm_use_anthropic_fallback2 || 'false' }}
           ocr_version: '1.8.6'
+          # Same artifact-name conflict as fallback 1.
+          upload_artifacts: 'false'
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
           head_sha: ${{ steps.pr-context.outputs.head_sha }}
 


### PR DESCRIPTION
A fallback attempt runs in the same job as the failed primary, so both compute the identical artifact name (`ocr-review-result-<run_id>-<run_attempt>`) and the fallback's upload 409s — failing the whole composite **after** a completed review. Net effect: a fully successful fallback review read as a failed attempt, the fail-gate turned the job red, and the computed comments were never posted.

Observed live on beauzone/marketing-as-code#302 during the 2026-08-20 primary-provider outage: the fallback logged `Review complete: 3 finding(s) across 6 selected item(s)` and the job still failed with `All configured OCR LLM backends failed`; the findings had to be recovered from the run log by hand.

Fix: fallback attempts pass `upload_artifacts: 'false'` (the action's documented input; quoted string per its own gating note). The fallback's result JSON is still printed to the job log — only the downloadable artifact is given up, and only on the fallback path. Primary behavior unchanged.

Follow-up chain: consuming repos pin this workflow by SHA since #33, so marketing-as-code's caller stub gets a pin bump to this commit once merged.

Authorized by Beau, 2026-08-20 (review-pipeline change — option 1 of the PR #302 unblock decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)