### PR TITLE
ci: allow the reviewer to be run on demand

### DIFF
--- a/.github/workflows/reviewer-agent.yml
+++ b/.github/workflows/reviewer-agent.yml
@@ -3,6 +3,16 @@ name: Automated PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # On-demand trigger. Without this the reviewer could only ever run as a side
+  # effect of opening a PR, which is part of why a retired model went unnoticed
+  # for six weeks (BEA-428): there was no way to ask "does the reviewer still
+  # work?" short of raising a pull request. A PR number is required because the
+  # script reads the diff and posts its review there.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
 
 jobs:
   review:
@@ -78,6 +88,6 @@ jobs:
           # full state space rather than issue another narrow fix to a region
           # earlier rounds already touched.
           REPETITION_WARNING_AFTER_CYCLES: "2"
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: python .agents/scripts/review_pr.py


### PR DESCRIPTION
Adds `workflow_dispatch` to `reviewer-agent.yml` so the review pipeline can be exercised without opening a pull request.

**Why this matters beyond convenience.** The reviewer could only ever run as a side effect of opening a PR. That is part of why the retired qwen3 model went unnoticed for six weeks (BEA-428) — there was no way to ask *does the reviewer still work?* short of raising a PR, so nobody asked. On-demand invocation makes the gate testable.

`workflow_dispatch` takes a required `pr_number` input, since the script reads that PR's diff and posts its review there. `PR_NUMBER` resolves from either trigger.

**Immediate purpose:** verifying that `OPENROUTER_API_KEY` — configured on this repo today — actually serves the primary tier. The chain has been running fallback-only until now, with the primary skipped as partially configured. This PR's own review run is the test: success logs `🧭 Router selected <model>`; failure still logs `⚠️ Ignoring partially configured provider tier(s): primary (missing api key)` and falls back, which is the current behaviour.

**MERGE POSTURE: HOLD FOR BEAU** — workflow change to the review pipeline. Not self-merging.