### PR TITLE
A storage fault can no longer discard a completed OCR review (BEA-474)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -25,16 +25,28 @@
 # fallback is skipped rather than failing on auth with a confusing message.
 # Leaving fallbacks unconfigured changes nothing.
 #
-# Fallback attempts set upload_artifacts: 'false'. The action names its
-# artifact ocr-review-result-<run_id>-<run_attempt>; a fallback runs in the
-# SAME job as the failed primary, so both attempts compute the same name and
-# the fallback's upload 409s ("artifact with this name already exists") —
-# which failed the whole composite AFTER a completed review, so a fully
-# successful fallback review still read as a failed attempt: the gate turned
-# the job red and the computed comments were never posted (observed live on
-# marketing-as-code PR #302 during the 2026-08-20 primary-provider outage).
-# The fallback's result JSON is still printed to the job log by the action;
-# only the downloadable artifact is given up, and only on the fallback path.
+# EVERY attempt sets upload_artifacts: 'false' — primary included (BEA-474).
+#
+# Inside the action the step order is: run review -> UPLOAD ARTIFACT ->
+# fail-on-error -> POST COMMENTS. The upload therefore sits between a
+# completed review and the posting of its findings, and those steps cannot be
+# reordered from here. Any upload failure aborts the composite before "Post
+# review comments" runs, so the review is computed, echoed to the job log, and
+# then silently discarded.
+#
+# Two live incidents, both of that shape. The artifact is named
+# ocr-review-result-<run_id>-<run_attempt>, and a fallback runs in the SAME job
+# as the failed primary, so both compute the same name and the second upload
+# 409s: marketing-as-code PR #302 during the 2026-08-20 primary-provider
+# outage, and beauzone/mac-engine#24 on 2026-08-28, where a completed review
+# that had found a real bug never reached the PR and was recovered only by
+# reading the raw job log. Disabling the fallback upload fixed the collision
+# but left the class open on the primary path, where a quota or a transient
+# 5xx does the same thing.
+#
+# The result JSON is still printed to the job log by the action's own
+# "=== OCR result ===" step. What is given up is a duplicate download; what is
+# bought is that a storage fault can no longer discard a review.
 #
 # The OCR action is pinned to a commit SHA (not @main) since it runs with
 # pull-requests: write and handles LLM/GitHub credentials.
@@ -189,6 +201,22 @@ jobs:
           llm_model: ${{ inputs.llm_model }}
           llm_use_anthropic: 'false'
           ocr_version: '1.8.6'
+          # The primary gives up its artifact too. Inside the action the step
+          # order is: run review -> UPLOAD ARTIFACT -> fail-on-error -> POST
+          # COMMENTS. The upload therefore sits between a completed review and
+          # the posting of its findings, and the action's steps cannot be
+          # reordered from here. Any upload failure — the run_id/run_attempt
+          # name colliding, a storage quota, a transient 5xx — aborts the
+          # composite before "Post review comments" runs, so the review is
+          # computed, printed to the job log, and then silently thrown away.
+          # That is not hypothetical: it happened on beauzone/mac-engine#24,
+          # where a completed review that had found a real bug never reached
+          # the PR and was only recovered by reading the raw job log (BEA-473,
+          # BEA-474). The result JSON is still echoed to the log by the action's
+          # own "=== OCR result ===" step, so what is given up is a duplicate
+          # download; what is bought is that a storage fault can no longer
+          # discard a review.
+          upload_artifacts: 'false'
           # For issue_comment triggers, pass the resolved refs; for
           # pull_request_target the action resolves them from the event.
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
@@ -261,5 +289,12 @@ jobs:
           FALLBACK2_OUTCOME: ${{ steps.ocr-fallback2.outcome }}
         shell: bash
         run: |
-          echo "::error::All configured OCR LLM backends failed (primary: ${PRIMARY_OUTCOME}, fallback1: ${FALLBACK1_OUTCOME}, fallback2: ${FALLBACK2_OUTCOME})."
+          # Deliberately does NOT claim the LLM backends failed. A step's
+          # `outcome` is failure if ANYTHING in that composite action failed —
+          # the LLM call, dependency install, checkout, comment posting — so
+          # naming the LLM here sends whoever debugs it to the wrong system.
+          # It did exactly that during the BEA-473 artifact-409 incident, where
+          # three LLM calls succeeded and this message still read "all backends
+          # failed". State what is known and point at where the cause is.
+          echo "::error::No OCR review attempt succeeded (primary: ${PRIMARY_OUTCOME}, fallback1: ${FALLBACK1_OUTCOME}, fallback2: ${FALLBACK2_OUTCOME}). This reports the *step* outcomes, which cover every stage of the review action, not the LLM call alone — open the failing attempt's log and read its last error before assuming a backend outage."
           exit 1


### PR DESCRIPTION
Two changes to the reusable OCR review workflow. Affects **every consuming repo**.

## 1. The upload sits between a completed review and its posting

Inside `alibaba/open-code-review` the step order is:

> run review → **UPLOAD ARTIFACT** → fail-on-error → **POST COMMENTS**

So any upload failure aborts the composite *before* `Post review comments` runs. The review is computed, echoed to the job log, and then silently thrown away. A caller cannot reorder the action's internal steps, so the only lever is whether the upload runs at all.

**This has happened twice.** The artifact is named `ocr-review-result-<run_id>-<run_attempt>`, and a fallback runs in the *same job* as the failed primary, so both compute the same name and the second upload 409s:

- `marketing-as-code` PR #302, during the 2026-08-20 primary-provider outage.
- `beauzone/mac-engine#24` on 2026-08-28 — a completed review that had found a real bug (`run_at` reaching `astimezone` naive) never reached the PR, and was recovered only by reading the raw job log. See BEA-473.

`bf86d3c` fixed the *collision* by disabling the fallback upload, but left the *class* open on the primary path, where a storage quota or a transient 5xx does exactly the same thing.

**Fix:** the primary sets `upload_artifacts: 'false'` too, removing the upload step from between the review and its posting entirely. The result JSON is still printed by the action's own `=== OCR result ===` step, so what is given up is a duplicate download; what is bought is that a storage fault can no longer discard a review.

## 2. The gate asserted a cause it had not established

A step's `outcome` is `failure` if **anything** in that composite failed — the LLM call, dependency install, checkout, comment posting. The gate nonetheless printed:

> All configured OCR LLM backends failed

During the BEA-473 incident, three LLM calls succeeded and that message still claimed every backend was down. It sends whoever debugs it to investigate provider credentials and quota, which is the wrong system entirely.

It now reports the step outcomes *as step outcomes*, states that they cover every stage of the action rather than the LLM call alone, and says to read the failing attempt's log before assuming a backend outage.

## What is not fixed here

BEA-474's third point — a fallback re-review can duplicate inline comments when the primary's posting failed partway — is unchanged. It is documented in the workflow header and deliberately accepted ("a duplicated review beats a silently missing one").

## Verification

**This cannot be verified from a build session, and I have not run it.** A reusable workflow only exercises on a real PR in a consuming repo, and the failure path specifically needs an upload fault. What I did instead: read `action.yml` at the pinned SHA (`a17e884c`) to establish the step ordering the fix depends on, and confirmed `upload_artifacts` is a real input gating the upload step (`if: always() && inputs.upload_artifacts == 'true'`).

The change is also strictly failure-reducing: it removes a step that can only ever fail, never one that produces the review or posts it.

## Rollout note

Consuming repos pin this workflow by commit SHA, so **merging here changes nothing until each repo is re-stamped**. That is the exact gap BEA-473 turned out to be — `marketing-as-code` was re-stamped after `bf86d3c` and `mac-engine` was not, leaving it on a known-broken version for eight days. Worth sweeping every consumer after this lands.

## Merge

Flagging rather than self-merging: CI configuration is a hold-for-Beau category, and this one changes shared CI for every repo at once.

Fixes BEA-474